### PR TITLE
support SemVer pre-release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Added
+
+-   support [SemVer pre-release versions](http://semver.org/#spec-item-9) e.g. 1.0.0-alpha.1
+
+
 ## 1.1.0 - 2017-01-13
 
 

--- a/__tests__/__snapshots__/diff.js.snap
+++ b/__tests__/__snapshots__/diff.js.snap
@@ -49,4 +49,8 @@ Object {
 
 exports[`test versionToMarkdown("^1.2.3", "CHANGELOG.md") 1`] = `"^[1.2.3](CHANGELOG.md)"`;
 
+exports[`test versionToMarkdown("1.0.0-x.7.z.92", "CHANGELOG.md") 1`] = `"[1.0.0-x.7.z.92](CHANGELOG.md)"`;
+
 exports[`test versionToMarkdown("1.2.3", "CHANGELOG.md") 1`] = `"[1.2.3](CHANGELOG.md)"`;
+
+exports[`test versionToMarkdown("1.2.3-alpha.1", "CHANGELOG.md") 1`] = `"[1.2.3-alpha.1](CHANGELOG.md)"`;

--- a/__tests__/diff.js
+++ b/__tests__/diff.js
@@ -49,6 +49,18 @@ test('versionToMarkdown("1.2.3", "CHANGELOG.md")', () => {
   expect(result).toMatchSnapshot()
 })
 
+// http://semver.org/#spec-item-9
+test('versionToMarkdown("1.2.3-alpha.1", "CHANGELOG.md")', () => {
+  const result = diff.versionToMarkdown('1.2.3-alpha.1', 'CHANGELOG.md')
+  expect(result).toMatchSnapshot()
+})
+
+// http://semver.org/#spec-item-9
+test('versionToMarkdown("1.0.0-x.7.z.92", "CHANGELOG.md")', () => {
+  const result = diff.versionToMarkdown('1.0.0-x.7.z.92', 'CHANGELOG.md')
+  expect(result).toMatchSnapshot()
+})
+
 test('versionToMarkdown("^1.2.3", "CHANGELOG.md")', () => {
   const result = diff.versionToMarkdown('^1.2.3', 'CHANGELOG.md')
   expect(result).toMatchSnapshot()

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -8,11 +8,15 @@ const semver = require('semver')
 
 const npm = require('./npm.js')
 
+// http://semver.org/#spec-item-9
+// 1.0.0, 1.0.0-foo1, 1.0.0-foo1.blah2, 1.0.0-foo1.blah2.abc3, ...
+const VERSION_REGEXP = /\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?/
+
 function versionToMarkdown (
   version /* : string */,
   changelogUrl /* : string */
 ) /* : string */ {
-  const [ versionNumbers ] = version.match(/\d+\.\d+\.\d+/) || []
+  const [ versionNumbers ] = version.match(VERSION_REGEXP) || []
   if (!versionNumbers) {
     return version
   }


### PR DESCRIPTION
### Added

-   support [SemVer pre-release versions](http://semver.org/#spec-item-9) e.g. 1.0.0-alpha.1
